### PR TITLE
handled second time requesting for video scenario

### DIFF
--- a/lib/webrtcclient.js
+++ b/lib/webrtcclient.js
@@ -1282,6 +1282,15 @@ if (!Brekeke.WebrtcClient) {
       if (endVideoCall) {
         session.localVideoEnabled = false
         session.remoteVideoEnabled = false
+        var remoteUserOptionsTable = {}
+        for (user in session.remoteUserOptionsTable) {
+          remoteUserOptions = session.remoteUserOptionsTable[user];
+          remoteUserOptionsTable[user] = {
+            withVideo: false,
+            exInfo: string(remoteUserOptions.exInfo),
+          };
+        }
+        session.remoteUserOptionsTable = remoteUserOptionsTable
       }
       this._emitEvent('sessionStatusChanged', this.getSession(sessionId));
     },


### PR DESCRIPTION
Handled below scenario
Once the video call is enabled for both parties, then if one user disables the video then the video should be disconnected for both parties, and when one user clicks on the video again then a new request should be sent to another user.